### PR TITLE
only enable webpack-hot-client for targeting web

### DIFF
--- a/HotClientEntryPlugin.js
+++ b/HotClientEntryPlugin.js
@@ -6,8 +6,13 @@ const uuid = require('uuid/v4');
 
 module.exports = class HotClientEntryPlugin {
   // eslint-disable-next-line class-methods-use-this
-  toPlugin(context, item, name) {
-    const hotEntry = [`webpack-hot-client/client?${name || uuid()}`];
+  toPlugin(compiler, context, item, name) {
+    const hotEntry = [];
+
+    if (compiler.options.target === 'web') {
+      hotEntry.push(`webpack-hot-client/client?${name || uuid()}`);
+    }
+
     const entry = hotEntry.concat(item);
 
     return new MultiEntryPlugin(context, entry, name);
@@ -16,9 +21,9 @@ module.exports = class HotClientEntryPlugin {
   apply(compiler) {
     compiler.plugin('entry-option', (context, entry) => {
       if (typeof entry === 'string' || Array.isArray(entry)) {
-        compiler.apply(this.toPlugin(context, entry, 'main'));
+        compiler.apply(this.toPlugin(compiler, context, entry, 'main'));
       } else if (typeof entry === 'object') {
-        Object.keys(entry).forEach(name => compiler.apply(this.toPlugin(context, entry[name], name)));
+        Object.keys(entry).forEach(name => compiler.apply(this.toPlugin(compiler, context, entry[name], name)));
       } else if (typeof entry === 'function') {
         // TODO support functions
         compiler.apply(new DynamicEntryPlugin(context, entry));

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "webpack": "^2.2.0 || ^3.0.0 || ^4.0.0-alpha"
   },
   "dependencies": {
-    "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.2",
     "babel-preset-env": "^1.6.1",


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!
  Please note that this template is not optional.
  Please fill out _ALL_ fields, or your pull request may be rejected.
  Please do not delete this template. Please do remove this header to acknowledge this message.`

  Please place an x, no spaces, in all [ ] that apply
-->

- [ ] This is a **bugfix**
- [ ] This is a new **feature**
- [x] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **typo fix**
- [ ] This is a **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for making this change.
  What existing problem does the pull request solve?
  If this Pull Request addresses an issue, please link to the issue.
-->

`webpack-hot-client` is using a hacking way to rewrite `EntryOptionPlugin.prototype.apply` which will affect all webpack compiler instance, and when we're implementing Server Side rendering with `webpack-hot-client` together, it will add `webpack-hot-client/client` to server compiler also, this is unexpected, it should only affected client compiler.

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

No

### Additional Info
although `babel-core` and `babel-loader` is needed at runtime, I don't see any usage of `babel-cli` inside. I should also fix issue working with babel@7
