### PR TITLE
fix for module.hot falsy

### DIFF
--- a/client/hot.js
+++ b/client/hot.js
@@ -93,7 +93,7 @@ function check() {
   });
 }
 
-if (typeof module.hot === 'object') {
+if (module.hot) {
   log.info('Hot Module Replacement Enabled. Waiting for signal.');
 } else {
   log.error('Hot Module Replacement is disabled.');

--- a/test/fixtures/app.js
+++ b/test/fixtures/app.js
@@ -4,7 +4,7 @@
 
 require('./component');
 
-if (typeof module.hot === 'object') {
+if (module.hot) {
   module.hot.accept((err) => {
     if (err) {
       console.error('Cannot apply HMR update.', err);


### PR DESCRIPTION

- [x] This is a **bugfix**
- [ ] This is a new **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **typo fix**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

n/a

### Motivation / Use-Case

Implements a fix for ensuring that HotModuleReplacementPlugin takes precedence when assigning value to `module.hot` 

### Breaking Changes

none

### Additional Info
