### PR TITLE
fix a bug where webpack.config with an array of strings entry was considered invalid

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -125,11 +125,11 @@ module.exports = {
       const { entry } = comp.options;
       const type = typeof entry;
 
-      if (!Array.isArray(entry) && type !== 'object') {
+      if (type !== 'object') {
         throw new TypeError('webpack-hot-client: The value of `entry` must be an Array or Object. Please check your webpack config.');
       }
 
-      if (type === 'object') {
+      if (!Array.isArray(entry)) {
         for (const key of Object.keys(entry)) {
           const value = entry[key];
           if (!Array.isArray(value)) {

--- a/test/fixtures/webpack.config-valid-array-of-string.js
+++ b/test/fixtures/webpack.config-valid-array-of-string.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const path = require('path');
+const webpack = require('webpack');
+
+module.exports = {
+  resolve: {
+    alias: {
+      'webpack-hot-client/client': path.resolve(__dirname, '../../client')
+    }
+  },
+  context: __dirname,
+  devtool: 'source-map',
+  entry: ['./app.js'],
+  mode: 'development',
+  output: {
+    filename: './output.js',
+    path: path.resolve(__dirname)
+  },
+  plugins: [
+    new webpack.NamedModulesPlugin()
+  ]
+};

--- a/test/init.js
+++ b/test/init.js
@@ -27,4 +27,13 @@ describe('Webpack Hot Client', () => {
 
     assert.throws(() => { client(compiler, options); });
   });
+
+  xit('should accept an array of string entry', (done) => {
+    const config = require('./fixtures/webpack.config-valid-array-of-string.js');
+    const compiler = webpack(config);
+    const options = { hot: true, logLevel: 'info', test: true };
+
+    var hotClient = client(compiler, options);
+    hotClient.close(() => done());
+  });
 });


### PR DESCRIPTION
- [x] This is a **bugfix**
- [ ] This is a new **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **typo fix**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

Yes, but it doesn't clean up after itself, so it causes further tests to fail, so it's ignored. Advice / assistance on cleaning it up would be great

### Motivation / Use-Case

`webpack.config` files that have `entry` as an array of strings, which are valid, were considered invalid, due to a bug in `validateEntry` considering an array of strings as an object of properties of arrays of strings (also valid, those test cases still pass).

### Breaking Changes

None

### Additional Info

Honestly in my opinion, it is not the responsibility of plugins to validate `webpack.config`, otherwise logic gets duplicated and maintenance bugs like this appear. I can submit a PR that just deletes this code if you wish.
