### PR TITLE
Only include min version of loglevelnext to prevent CSP issues

### DIFF
--- a/lib/client/log.js
+++ b/lib/client/log.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-const loglevel = require('loglevelnext/dist/loglevelnext');
+const loglevel = require('loglevelnext/dist/loglevelnext.min.js');
 
 const { MethodFactory } = loglevel.factories;
 const css = {


### PR DESCRIPTION
Fixes shellscape/loglevelnext#2

- [x] This is a **bugfix**

### For Bugs and Features; did you add new tests?

No. The change is small enough.

### Motivation / Use-Case

See https://github.com/shellscape/loglevelnext/issues/2