### PR TITLE
allow the host option to be an object

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,12 +90,20 @@ Type: `Object`
 
 ##### host
 
-Type: `Object`  
+Type: `String|Object`  
 Default: `'localhost'`
 
 Sets the host that the `WebSocket` server will listen on. If this doesn't match
-the host of the server the module is used with, the module will not function
-properly.
+the host of the server the module is used with, the module may not function
+properly. If the `server` option is defined, this option is ignored.
+
+If using the module in a specialized environment, you may choose to specify an
+`object` to define `client` and `server` host separately. The `object` value
+should match `{ client: <String>, server: <String> }`. Be aware that the `client`
+host will be used _in the browser_ by `WebSockets`. You should not use this
+option in this way unless _you know what you're doing._ Using a mismatched
+`client` and `server` host will be **unsupported by the project** as the behavior
+in the browser can be unpredictable and is specific to a particular environment.
 
 ##### hot
 

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 const weblog = require('webpack-log');
 const WebSocket = require('ws');
+const HotClientError = require('./lib/HotClientError');
 const { modifyCompiler, payload, sendStats, validateEntry } = require('./lib/util');
 
 const defaults = {
@@ -29,10 +30,27 @@ module.exports = (compiler, opts) => {
     timestamp: options.logTime
   });
 
+  if (typeof options.host === 'string') {
+    options.host = {
+      server: options.host,
+      client: options.host
+    };
+  } else if (!options.host.server) {
+    throw new HotClientError('`options.server` must be defined when setting host to an Object');
+  } else if (!options.host.client) {
+    throw new HotClientError('`options.client` must be defined when setting host to an Object');
+  }
+
+  /* istanbul ignore if */
+  if (options.host.client !== options.host.server) {
+    log.warn('`options.host.client` does not match `options.host.server`. This can cause unpredictable behavior in the browser.');
+  }
+
   validateEntry(compiler);
 
   const { host, port, server } = options;
-  const wss = new WebSocket.Server(options.server ? { server } : { host, port });
+  const wssOptions = options.server ? { server } : { host: host.server, port };
+  const wss = new WebSocket.Server(wssOptions);
   let stats;
 
   options.log = log;
@@ -58,7 +76,7 @@ module.exports = (compiler, opts) => {
       port: wss._server.address().port // eslint-disable-line no-underscore-dangle
     };
   } else {
-    options.webSocket = { host, port };
+    options.webSocket = { host: host.client, port };
   }
 
   modifyCompiler(compiler, options);
@@ -89,7 +107,6 @@ module.exports = (compiler, opts) => {
     broadcast(payload('invalid'));
   };
 
-
   if (compiler.hooks) {
     // as of webpack@4 MultiCompiler no longer exports the compile hook
     const compilers = compiler.compilers || [compiler];
@@ -105,15 +122,14 @@ module.exports = (compiler, opts) => {
     compiler.plugin('done', done);
   }
 
-
   wss.on('error', (err) => {
     log.error('WebSocket Server Error', err);
   });
 
   wss.on('listening', () => {
     // eslint-disable-next-line no-shadow
-    const { host, port } = options.webSocket;
-    log.info(`WebSocket Server Listening at ${host}:${port}`);
+    const { host, port } = options;
+    log.info(`WebSocket Server Listening at ${host.server}:${port}`);
   });
 
   wss.on('connection', (socket) => {
@@ -144,7 +160,7 @@ module.exports = (compiler, opts) => {
         log.error(err);
       }
     },
-
+    options: Object.freeze(Object.assign({}, options)),
     wss
   };
 };

--- a/lib/HotClientError.js
+++ b/lib/HotClientError.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = class HotClientError extends Error {
+  constructor(message) {
+    super(`webpack-hot-client: ${message}`);
+  }
+};

--- a/test/tests/init.js
+++ b/test/tests/init.js
@@ -38,6 +38,74 @@ describe('Webpack Hot Client', () => {
     setTimeout(() => { close(done); }, 2000);
   }).timeout(4000);
 
+  it('should allow setting host', (done) => {
+    const config = require('../fixtures/webpack.config-array.js');
+    const compiler = webpack(config);
+    const options = { host: '0.0.0.0', hot: true, logLevel: 'info' };
+    const { close, wss } = client(compiler, options);
+
+    setTimeout(() => {
+      assert.equal(wss._server.address().address, options.host); // eslint-disable-line no-underscore-dangle
+      close(done);
+    }, 2000);
+  }).timeout(4000);
+
+  it('should allow setting host object', (done) => {
+    const config = require('../fixtures/webpack.config-array.js');
+    const compiler = webpack(config);
+    const options = {
+      host: { client: '127.0.0.1', server: '127.0.0.1' },
+      hot: true,
+      logLevel: 'info'
+    };
+    const { close, options: opts, wss } = client(compiler, options);
+
+    assert.equal(opts.host.client, options.host.client);
+    assert.equal(opts.webSocket.host, options.host.client);
+    assert.equal(opts.host.server, options.host.server);
+
+    setTimeout(() => {
+      assert.equal(wss._server.address().address, options.host.server); // eslint-disable-line no-underscore-dangle
+      close(done);
+    }, 2000);
+  }).timeout(4000);
+
+  it('should allow setting host object with different client', (done) => {
+    const config = require('../fixtures/webpack.config-array.js');
+    const compiler = webpack(config);
+    const options = {
+      host: { client: '127.0.0.1', server: '0.0.0.0' },
+      hot: true,
+      logLevel: 'info'
+    };
+    const { close, options: opts, wss } = client(compiler, options);
+
+    assert.equal(opts.host.client, options.host.client);
+    assert.equal(opts.webSocket.host, options.host.client);
+    assert.equal(opts.host.server, options.host.server);
+
+    setTimeout(() => {
+      assert.equal(wss._server.address().address, options.host.server); // eslint-disable-line no-underscore-dangle
+      close(done);
+    }, 2000);
+  }).timeout(4000);
+
+  it('should not allow setting host object missing server', () => {
+    const config = require('../fixtures/webpack.config-array.js');
+    const compiler = webpack(config);
+    const options = { host: { client: 'localhost' } };
+
+    assert.throws(() => { client(compiler, options); });
+  });
+
+  it('should not allow setting host object missing client', () => {
+    const config = require('../fixtures/webpack.config-array.js');
+    const compiler = webpack(config);
+    const options = { host: { server: 'localhost' } };
+
+    assert.throws(() => { client(compiler, options); });
+  });
+
   it('should allow passing koa server instance', (done) => {
     const server = http.createServer();
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!
  Please note that this template is not optional.
  Please fill out _ALL_ fields, or your pull request may be rejected.
  Please do not delete this template. Please do remove this header to acknowledge this message.`

  Please place an x, no spaces, in all [ ] that apply
-->

- [ ] This is a **bugfix**
- [x] This is a new **feature**
- [ ] This is a **code refactor**
- [x] This is a **test update**
- [ ] This is a **typo fix**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

Yes

### Motivation / Use-Case

Situations in which the host needs to be defined separately for server and client are starting to become more common. This allows for `{ client: <String>, server: <String> }`.

### Breaking Changes

None

### Additional Info
