### PR TITLE
allow entries to be functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .nyc_output
 node_modules
 coverage
-test/fixtures/output.js
+test/fixtures/output.js*
 client/*.js
 coverage.lcov

--- a/README.md
+++ b/README.md
@@ -36,7 +36,16 @@ To begin, you'll need to install `webpack-hot-client`:
 $ npm install webpack-hot-client --save-dev
 ```
 
-_Reminder: You don't have to modify your config at all!_
+## Gotchas
+
+In order to use `webpack-hot-client`, your `webpack` config should include an
+`entry` option that is set to an `Array` of `String`, or an `Object` who's keys
+are set to an `Array` of `String`. You may also use a `Function`, but that
+function should return a value in one of the two valid formats.
+
+This is primarily due to restrictions in
+`webpack` itself and the way that it processes options and entries. For users of
+webpack v4+ that go the zero-config route, you must specify an `entry` option.
 
 ### Express
 

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 const weblog = require('webpack-log');
 const WebSocket = require('ws');
-const { modifyCompiler, payload, sendStats, validateEntry } = require('./lib/util');
+const { modifyCompiler, payload, sendStats, validateCompiler } = require('./lib/util');
 
 const defaults = {
   host: 'localhost',
@@ -29,7 +29,7 @@ module.exports = (compiler, opts) => {
     timestamp: options.logTime
   });
 
-  validateEntry(compiler);
+  validateCompiler(compiler);
 
   const { host, port, server } = options;
   const wss = new WebSocket.Server(options.server ? { server } : { host, port });

--- a/lib/util.js
+++ b/lib/util.js
@@ -5,14 +5,9 @@ const stringify = require('json-stringify-safe');
 const uuid = require('uuid/v4');
 const webpack = require('webpack');
 
-function hotEntry(compiler) {
-  if (compiler.options.target !== 'web') {
-    return;
-  }
 
-  const { entry } = compiler.options;
-  const { name } = compiler;
-  const clientEntry = [`webpack-hot-client/client?${name || uuid()}`];
+function addEntry(entry, compilerName) {
+  const clientEntry = [`webpack-hot-client/client?${compilerName || uuid()}`];
   let newEntry = {};
 
   if (!Array.isArray(entry) && typeof entry === 'object') {
@@ -25,6 +20,34 @@ function hotEntry(compiler) {
   } else {
     newEntry = clientEntry.concat(entry);
   }
+
+  return newEntry;
+}
+
+function hotEntry(compiler) {
+  if (compiler.options.target !== 'web') {
+    return;
+  }
+
+  const { entry } = compiler.options;
+  const { name } = compiler;
+  let newEntry;
+
+  if (typeof entry === 'function') {
+    newEntry = function enter(...args) {
+      // the entry result from the original entry function in the config
+      let result = entry(...args);
+
+      validateEntry(result);
+
+      result = addEntry(result, name);
+
+      return result;
+    };
+  } else {
+    newEntry = addEntry(entry, name);
+  }
+
 
   if (compiler.hooks) {
     compiler.hooks.entryOption.call(compiler.options.context, newEntry);
@@ -65,6 +88,26 @@ function hotPlugin(compiler) {
         parser._plugins['evaluate Identifier module.hot'].reverse();
       });
     });
+  }
+}
+
+function validateEntry(entry) {
+  const type = typeof entry;
+  const isArray = Array.isArray(entry);
+
+  if (type !== 'function') {
+    if (!isArray && type !== 'object') {
+      throw new TypeError('webpack-hot-client: The value of `entry` must be an Array, Object, or Function. Please check your webpack config.');
+    }
+
+    if (!isArray && type === 'object') {
+      for (const key of Object.keys(entry)) {
+        const value = entry[key];
+        if (!Array.isArray(value)) {
+          throw new TypeError('webpack-hot-client: `entry` Object values must be an Array or Function. Please check your webpack config.');
+        }
+      }
+    }
   }
 }
 
@@ -114,24 +157,10 @@ module.exports = {
     }
   },
 
-  validateEntry(compiler) {
+  validateCompiler(compiler) {
     for (const comp of [].concat(compiler.compilers || compiler)) {
       const { entry } = comp.options;
-      const type = typeof entry;
-      const isArray = Array.isArray(entry);
-
-      if (!isArray && type !== 'object') {
-        throw new TypeError('webpack-hot-client: The value of `entry` must be an Array or Object. Please check your webpack config.');
-      }
-
-      if (!isArray && type === 'object') {
-        for (const key of Object.keys(entry)) {
-          const value = entry[key];
-          if (!Array.isArray(value)) {
-            throw new TypeError('webpack-hot-client: `entry` Object values must be an Array. Please check your webpack config.');
-          }
-        }
-      }
+      validateEntry(entry);
     }
   }
 };

--- a/test/fixtures/webpack.config-function-invalid.js
+++ b/test/fixtures/webpack.config-function-invalid.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const path = require('path');
+const TimeFixPlugin = require('time-fix-plugin');
+const webpack = require('webpack');
+
+module.exports = {
+  resolve: {
+    alias: {
+      'webpack-hot-client/client': path.resolve(__dirname, '../../client')
+    }
+  },
+  context: __dirname,
+  devtool: 'source-map',
+  entry: () => './app.js',
+  mode: 'development',
+  output: {
+    filename: './output.js',
+    path: path.resolve(__dirname)
+  },
+  plugins: [
+    new webpack.NamedModulesPlugin(),
+    new TimeFixPlugin()
+  ]
+};

--- a/test/fixtures/webpack.config-function.js
+++ b/test/fixtures/webpack.config-function.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const path = require('path');
+const TimeFixPlugin = require('time-fix-plugin');
+const webpack = require('webpack');
+
+module.exports = {
+  resolve: {
+    alias: {
+      'webpack-hot-client/client': path.resolve(__dirname, '../../client')
+    }
+  },
+  context: __dirname,
+  devtool: 'source-map',
+  entry: () => ['./app.js'],
+  mode: 'development',
+  output: {
+    filename: './output.js',
+    path: path.resolve(__dirname)
+  },
+  plugins: [
+    new webpack.NamedModulesPlugin(),
+    new TimeFixPlugin()
+  ]
+};

--- a/test/tests/init.js
+++ b/test/tests/init.js
@@ -38,6 +38,29 @@ describe('Webpack Hot Client', () => {
     setTimeout(() => { close(done); }, 2000);
   }).timeout(4000);
 
+  it('should allow function entry that returns array', (done) => {
+    const config = require('../fixtures/webpack.config-function.js');
+    const compiler = webpack(config);
+    const options = { hot: true, logLevel: 'info' };
+    const { close } = client(compiler, options);
+
+    setTimeout(() => {
+      compiler.run(() => { close(done); });
+    }, 2000);
+  }).timeout(4000);
+
+  it('should reject function entry that returns string', (done) => {
+    const config = require('../fixtures/webpack.config-function-invalid.js');
+    const compiler = webpack(config);
+    const options = { hot: true, logLevel: 'info' };
+    const { close } = client(compiler, options);
+
+    setTimeout(() => {
+      assert.throws(() => { compiler.run(); }, TypeError, /must be an Array/);
+      close(done);
+    }, 2000);
+  }).timeout(4000);
+
   it('should allow passing koa server instance', (done) => {
     const server = http.createServer();
 

--- a/test/tests/sockets.js
+++ b/test/tests/sockets.js
@@ -6,7 +6,6 @@ const fs = require('fs');
 const path = require('path');
 const assert = require('assert');
 const MemoryFileSystem = require('memory-fs');
-const touch = require('touch');
 const webpack = require('webpack');
 const WebSocket = require('ws');
 const webpackPackage = require('webpack/package.json');
@@ -90,53 +89,6 @@ describe('Sockets', function d() {
       done();
     });
   });
-
-  // webpack@3 was very predictable here. webpack@4 is now very unpredictable,
-  // so these aren't good tests for that version. keeping in place for v3.
-  if (webpackVersion < 4) {
-    it('sockets should receive messages', (done) => {
-      const valid = [
-        'compile',
-        'hash',
-        'invalid',
-        'ok'
-      ];
-      const received = [].concat(valid);
-      const socket = new WebSocket('ws://localhost:8081');
-
-      valid.push('warnings');
-
-      socket.on('message', (data) => {
-        const message = parse(data);
-
-        // travis running on trusty doesn't recognize touching a file as
-        // invalidating it, so it means the same thing here.
-        if (message.type === 'no-change') {
-          message.type = 'invalid';
-        }
-
-        if (valid.includes(message.type)) {
-          if (message.type === 'hash') {
-            assert(message.data);
-          }
-
-          const index = received.indexOf(message.type);
-          if (index >= 0) {
-            received.splice(index, 1);
-          }
-        } else {
-          throw new Error(`Unknown Message Type: ${message.type}`);
-        }
-
-        if (!received.length) {
-          socket.close();
-          done();
-        }
-      });
-
-      touch(entryPath);
-    }).timeout(10000);
-  }
 
   it('sockets should receive warnings on change', (done) => {
     // eslint-disable-next-line


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!
  Please note that this template is not optional.
  Please fill out _ALL_ fields, or your pull request may be rejected.
  Please do not delete this template. Please do remove this header to acknowledge this message.`

  Please place an x, no spaces, in all [ ] that apply
-->

- [x] This is a **bugfix**
- [ ] This is a new **feature**
- [ ] This is a **code refactor**
- [x] This is a **test update**
- [ ] This is a **typo fix**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

Yes

### Motivation / Use-Case

Supersedes #32, fixes webpack/webpack#6718.

According to https://webpack.js.org/configuration/entry-context/#entry, entries can also be functions. hot-client didn't previously account for that, adding neither the client scripts nor validating the entry function result.

### Breaking Changes

None

### Additional Info
