### PR TITLE
fixes #36. add envar to allow build target override

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,20 @@ Default: `{ context: process.cwd() }`
 An object specifying the webpack [stats][stats] configuration. This does not
 typically need to be modified.
 
+## Webpack Build Targets
+
+By default, `webpack-hot-client` is meant to, and expects to function on the
+[`'web'` build target](https://webpack.js.org/configuration/target). However,
+you can manipulate this by setting the `WHC_TARGET` environment variable. eg.
+
+```console
+$ export WHC_TARGET=electon-renderer; webpack-serve ...
+```
+
+Or by setting `process.env.WHC_TARGET` before executing the API.
+
+_Note: Changing this value is allowed but is **unsupported**._
+
 ## Contributing
 
 We welcome your contributions! Please have a read of [CONTRIBUTING.md](CONTRIBUTING.md) for more information on how to get involved.

--- a/lib/util.js
+++ b/lib/util.js
@@ -25,7 +25,7 @@ function addEntry(entry, compilerName) {
 }
 
 function hotEntry(compiler) {
-  if (compiler.options.target !== 'web') {
+  if (compiler.options.target !== process.env.WHC_TARGET) {
     return;
   }
 
@@ -48,47 +48,28 @@ function hotEntry(compiler) {
     newEntry = addEntry(entry, name);
   }
 
-
-  if (compiler.hooks) {
-    compiler.hooks.entryOption.call(compiler.options.context, newEntry);
-  } else {
-    compiler.applyPluginsBailResult('entry-option', compiler.options.context, newEntry);
-  }
+  compiler.hooks.entryOption.call(compiler.options.context, newEntry);
 }
 
 function hotPlugin(compiler) {
   const hmrPlugin = new webpack.HotModuleReplacementPlugin();
 
-  if (compiler.hooks) {
-    // webpack@4
-    // eslint-disable-next-line no-loop-func
-    compiler.hooks.compilation.tap('HotModuleReplacementPlugin', (compilation, {
-      normalModuleFactory
-    }) => {
-      const handler = (parser) => {
-        parser.hooks.evaluateIdentifier.for('module.hot').tap({
-          name: 'HotModuleReplacementPlugin',
-          before: 'NodeStuffPlugin'
-        }, expr => ParserHelpers.evaluateToIdentifier('module.hot', !!parser.state.compilation.hotUpdateChunkTemplate)(expr));
-      };
+  /* istanbul ignore next */
+  compiler.hooks.compilation.tap('HotModuleReplacementPlugin', (compilation, {
+    normalModuleFactory
+  }) => {
+    const handler = (parser) => {
+      parser.hooks.evaluateIdentifier.for('module.hot').tap({
+        name: 'HotModuleReplacementPlugin',
+        before: 'NodeStuffPlugin'
+      }, expr => ParserHelpers.evaluateToIdentifier('module.hot', !!parser.state.compilation.hotUpdateChunkTemplate)(expr));
+    };
 
-      normalModuleFactory.hooks.parser.for('javascript/auto').tap('HotModuleReplacementPlugin', handler);
-      normalModuleFactory.hooks.parser.for('javascript/dynamic').tap('HotModuleReplacementPlugin', handler);
-    });
+    normalModuleFactory.hooks.parser.for('javascript/auto').tap('HotModuleReplacementPlugin', handler);
+    normalModuleFactory.hooks.parser.for('javascript/dynamic').tap('HotModuleReplacementPlugin', handler);
+  });
 
-    hmrPlugin.apply(compiler);
-  } else {
-    // webpack < 4
-    // must come first
-    hmrPlugin.apply(compiler);
-
-    compiler.plugin('compilation', (compilation, data) => {
-      data.normalModuleFactory.plugin('parser', (parser) => {
-        // eslint-disable-next-line no-underscore-dangle
-        parser._plugins['evaluate Identifier module.hot'].reverse();
-      });
-    });
-  }
+  hmrPlugin.apply(compiler);
 }
 
 function validateEntry(entry) {
@@ -143,6 +124,7 @@ module.exports = {
       return;
     }
 
+    /* istanbul ignore if */
     if (stats.assets && stats.assets.every(asset => !asset.emitted)) {
       send('no-change');
       return;

--- a/test/fixtures/webpack.config-object.js
+++ b/test/fixtures/webpack.config-object.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const path = require('path');
+const TimeFixPlugin = require('time-fix-plugin');
+const webpack = require('webpack');
+
+module.exports = {
+  resolve: {
+    alias: {
+      'webpack-hot-client/client': path.resolve(__dirname, '../../client')
+    }
+  },
+  context: __dirname,
+  devtool: 'source-map',
+  entry: {
+    main: ['./app.js']
+  },
+  output: {
+    filename: './output.js',
+    path: path.resolve(__dirname)
+  },
+  plugins: [
+    new webpack.NamedModulesPlugin(),
+    new TimeFixPlugin()
+  ]
+};

--- a/test/tests/init.js
+++ b/test/tests/init.js
@@ -9,6 +9,10 @@ const webpack = require('webpack');
 const client = require('../../index');
 
 describe('Webpack Hot Client', () => {
+  beforeEach(() => {
+    process.env.WHC_TARGET = '';
+  });
+
   it('should exist', () => {
     assert(client);
   });
@@ -29,13 +33,50 @@ describe('Webpack Hot Client', () => {
     assert.throws(() => { client(compiler, options); });
   });
 
-  it('should allow object with string array entry', (done) => {
+  it('should allow string array entry', (done) => {
     const config = require('../fixtures/webpack.config-array.js');
     const compiler = webpack(config);
     const options = { hot: true, logLevel: 'info' };
     const { close } = client(compiler, options);
 
     setTimeout(() => { close(done); }, 2000);
+  }).timeout(4000);
+
+  it('should allow object with string array entry', (done) => {
+    const config = require('../fixtures/webpack.config-object.js');
+    const compiler = webpack(config);
+    const options = { hot: true, logLevel: 'info' };
+    const { close } = client(compiler, options);
+
+    setTimeout(() => { close(done); }, 2000);
+  }).timeout(4000);
+
+  it('should set WHC_TARGET to web', (done) => {
+    const config = require('../fixtures/webpack.config-array.js');
+    const compiler = webpack(config);
+    const options = { hot: true, logLevel: 'info' };
+    const { close } = client(compiler, options);
+
+    setTimeout(() => {
+      assert.equal(process.env.WHC_TARGET, 'web');
+      close(done);
+    }, 2000);
+  }).timeout(4000);
+
+  it('should allow setting WHC_TARGET', (done) => {
+    process.env.WHC_TARGET = 'electron-renderer';
+
+    const config = require('../fixtures/webpack.config-array.js');
+    config.target = 'electron-renderer';
+
+    const compiler = webpack(config);
+    const options = { hot: true, logLevel: 'info' };
+    const { close } = client(compiler, options);
+
+    setTimeout(() => {
+      assert.equal(process.env.WHC_TARGET, 'electron-renderer');
+      close(done);
+    }, 2000);
   }).timeout(4000);
 
   it('should allow setting host', (done) => {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!
  Please note that this template is not optional.
  Please fill out _ALL_ fields, or your pull request may be rejected.
  Please do not delete this template. Please do remove this header to acknowledge this message.`

  Please place an x, no spaces, in all [ ] that apply
-->

- [ ] This is a **bugfix**
- [x] This is a new **feature**
- [x] This is a **code refactor**
- [x] This is a **test update**
- [ ] This is a **typo fix**
- [x] This is a **metadata update**

### For Bugs and Features; did you add new tests?

Yes

### Motivation / Use-Case

#38 outlines the need for certain unconventional (for this module) environment build targets to be able to run hot-client. This PR adds the ability to change `process.env.WHC_TARGET` to allow other build clients. 

### Breaking Changes

None. But users of webpack 3 who ignored the warnings and release notes for 2.0.0 will see breakage. This will be released as a minor version. 

### Additional Info
