### PR TITLE
Add Ability to Broadcast to Client Sockets

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,31 @@ Default: `{ context: process.cwd() }`
 An object specifying the webpack [stats][stats] configuration. This does not
 typically need to be modified.
 
+## Communicating with Client WebSockets
+
+In some rare situations, you may have the need to communicate with the attached
+`WebSockets` in the browser. To accomplish this, open a new `WebSocket` to the
+server, and send a `broadcast` message. eg.
+
+```js
+const stringify = require('json-stringify-safe');
+const { WebSocket } = require('ws');
+
+const socket = new WebSocket('ws://localhost:8081'); // this should match the server settings
+const data = {
+  type: 'broadcast',
+  data: { // the message you want to broadcast
+    type: '<something fun>', // the message type you want to broadcast
+    data: { ... } // the message data you want to broadcast
+  }
+};
+
+socket.send(stringify(data));
+```
+
+_Note: The `data` property of the message should contain the enveloped message
+you wish to broadcast to all other client `WebSockets`._
+
 ## Contributing
 
 We welcome your contributions! Please have a read of [CONTRIBUTING.md](CONTRIBUTING.md) for more information on how to get involved.

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const stringify = require('json-stringify-safe');
 const weblog = require('webpack-log');
 const WebSocket = require('ws');
 const HotClientError = require('./lib/HotClientError');
@@ -138,6 +139,18 @@ module.exports = (compiler, opts) => {
     socket.on('error', (err) => {
       if (err.errno !== 'ECONNRESET') {
         log.warn('client socket error', JSON.stringify(err));
+      }
+    });
+
+    socket.on('message', (data) => {
+      const message = JSON.parse(data);
+
+      if (message.type === 'broadcast') {
+        for (const client of wss.clients) {
+          if (client.readyState === WebSocket.OPEN) {
+            client.send(stringify(message.data));
+          }
+        }
       }
     });
 

--- a/lib/client/index.js
+++ b/lib/client/index.js
@@ -70,6 +70,10 @@ socket(options, {
     reload();
   },
 
+  'window-reload': () => {
+    window.location.reload();
+  },
+
   warnings(warnings) {
     log.warn('Warnings while compiling.');
 

--- a/test/tests/sockets.js
+++ b/test/tests/sockets.js
@@ -90,6 +90,31 @@ describe('Sockets', function d() {
     });
   });
 
+  it('should broadcast to child sockets', (done) => {
+    const socket = new WebSocket('ws://localhost:8081');
+    const socket2 = new WebSocket('ws://localhost:8081');
+
+    assert(socket);
+
+    socket.on('open', () => {
+      socket2.on('open', () => {
+        socket.on('message', (data) => {
+          const message = JSON.parse(data);
+
+          assert(message, 'test');
+          socket.close();
+          socket2.close();
+          done();
+        });
+
+        socket2.send(JSON.stringify({
+          type: 'broadcast',
+          data: 'test'
+        }));
+      });
+    });
+  });
+
   it('sockets should receive warnings on change', (done) => {
     // eslint-disable-next-line
     const warningCode = '\nconsole.log(require)';


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!
  Please note that this template is not optional.
  Please fill out _ALL_ fields, or your pull request may be rejected.
  Please do not delete this template. Please do remove this header to acknowledge this message.`

  Please place an x, no spaces, in all [ ] that apply
-->

- [ ] This is a **bugfix**
- [x] This is a new **feature**
- [ ] This is a **code refactor**
- [x] This is a **test update**
- [ ] This is a **typo fix**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

Yes

### Motivation / Use-Case

For certain recipes, such as watching files or implementing progress feedback, the socket server needs the ability to accept and broadcast a message to all other client sockets. For instance, to reload the window.

This PR adds that ability, and adds a new socket handler in the client, `window-reload` which serves only to reload the page without any special logic.

### Breaking Changes

None

### Additional Info
