### PR TITLE
Add slashes to `socketUrl`

### DIFF
--- a/lib/client/socket.js
+++ b/lib/client/socket.js
@@ -10,7 +10,8 @@ module.exports = function connect(options, handler) {
   const socketUrl = url.format({
     protocol: options.https ? 'wss' : 'ws',
     hostname: options.webSocket.host,
-    port: options.webSocket.port
+    port: options.webSocket.port,
+    slashes: true
   });
 
   let open = false;


### PR DESCRIPTION
- [x] This is a **bugfix**
- [ ] This is a new **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **typo fix**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

No need I believe. I could not find any tests for the client.

### Motivation / Use-Case

Socket URL generated by `url.format` does not include forward slashes (`//`) which causes IE11/Edge to throw `SyntaxError`s. Apparently node does it automatically for few protocols, but not for `ws`/`wss`.

| Before | After |
| - | - |
| `ws:0.0.0.0:8081` | `ws://0.0.0.0:8081` |
| `wss:192.168.113.76:8081` | `wss://192.168.113.76:8081` |

### Breaking Changes

None

### Additional Info

It seems to be just fine on Chrome, but Edge and IE 11 (yes, [IE 11 is actually there](https://caniuse.com/#feat=websockets)) give up straight away unless these slashes are in place.

This lib's node requirement is >=6, `slashes` property within `url.format` seems to be supported since forever, probably since `format` came out with v0.1.25: https://nodejs.org/api/url.html#url_url_format_urlobject
> If either of the following conditions is true, then the literal string // will be appended to result:
>  - urlObject.slashes property is true;
>  - urlObject.protocol begins with http, https, ftp, gopher, or file;

Also see:
  - https://docs.microsoft.com/en-us/microsoft-edge/dev-guide/networking-and-connectivity/websocket#using-a-websocket-client
  - https://tools.ietf.org/html/rfc6455#section-11.1.2