### PR TITLE
Use minified version of loglevelnext to avoid eval() calls

### DIFF
--- a/lib/client/log.js
+++ b/lib/client/log.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-const loglevel = require('loglevelnext/dist/loglevelnext');
+const loglevel = require('loglevelnext/dist/loglevelnext.min');
 
 const { MethodFactory } = loglevel.factories;
 const css = {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!
  Please note that this template is not optional.
  Please fill out _ALL_ fields, or your pull request may be rejected.
  Please do not delete this template. Please do remove this header to acknowledge this message.`

  Please place an x, no spaces, in all [ ] that apply
-->

- [x] This is a **bugfix**
- [ ] This is a new **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **typo fix**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

I just switched from `loglevelnext.js` to `loglevelnext.min.js`. All tests remain valid.

### Motivation / Use-Case

On some configuration with strict Content-Securicy-Policies, eval calls inside LogLevelNext are breaking client code of `webpack-hot-client`. One particular use-case is when developing chrome extensions: 
```Uncaught EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'self' blob: filesystem: chrome-extension-resource:".```


### Breaking Changes

No breaking changes.

### Additional Info
Another way to fix this is to change the `devtool` option in the webpack config of [LogLevelNext](https://github.com/shellscape/loglevelnext) to use sourcemap generation without eval (like `cheap-source-map`)
