### PR TITLE
fix: duplicate logging in MultiCompilers. fixes #47

### DIFF
--- a/lib/client/index.js
+++ b/lib/client/index.js
@@ -1,92 +1,104 @@
 'use strict';
 
-// this is piped in at runtime build via DefinePlugin in /lib/plugins.js
-// eslint-disable-next-line no-unused-vars, no-undef
-const options = __hotClientOptions__;
+/* eslint-disable global-require */
 
-const log = require('./log'); // eslint-disable-line import/order
-
-log.level = options.logLevel;
-
-const update = require('./hot');
-const socket = require('./socket');
-
-if (!options) {
-  throw new Error('Something went awry and __hotClientOptions__ is undefined. Possible bad build. HMR cannot be enabled.');
-}
-
-let currentHash;
-let initial = true;
-let isUnloading;
-
-window.addEventListener('beforeunload', () => {
-  isUnloading = true;
-});
-
-function reload() {
-  if (isUnloading) {
+(function hotClientEntry() {
+  // eslint-disable-next-line no-underscore-dangle
+  if (window.__webpackHotClient__) {
     return;
   }
 
-  if (options.hot) {
-    log.info('App Updated, Reloading Modules');
-    update(currentHash, options);
-  } else if (options.reload) {
-    log.info('Refreshing Page');
-    window.location.reload();
-  } else {
-    log.warn('Please refresh the page manually.');
-    log.info('The `hot` and `reload` options are set to false.');
-  }
-}
+  // eslint-disable-next-line no-underscore-dangle
+  window.__webpackHotClient__ = {};
 
-socket(options, {
-  compile() {
-    log.info('webpack: Compiling...');
-  },
+  // this is piped in at runtime build via DefinePlugin in /lib/plugins.js
+  // eslint-disable-next-line no-unused-vars, no-undef
+  const options = __hotClientOptions__;
 
-  errors(errors) {
-    log.error('webpack: Encountered errors while compiling. Reload prevented.');
+  const log = require('./log'); // eslint-disable-line import/order
 
-    for (let i = 0; i < errors.length; i++) {
-      log.error(errors[i]);
-    }
-  },
+  log.level = options.logLevel;
 
-  hash(hash) {
-    currentHash = hash;
-  },
+  const update = require('./hot');
+  const socket = require('./socket');
 
-  invalid() {
-    log.info('App updated. Recompiling');
-  },
-
-  ok() {
-    if (initial) {
-      initial = false;
-      return initial;
-    }
-
-    reload();
-  },
-
-  'window-reload': () => {
-    window.location.reload();
-  },
-
-  warnings(warnings) {
-    log.warn('Warnings while compiling.');
-
-    for (let i = 0; i < warnings.length; i++) {
-      log.warn(warnings[i]);
-    }
-
-    if (initial) {
-      initial = false;
-      return initial;
-    }
-
-    reload();
+  if (!options) {
+    throw new Error('Something went awry and __hotClientOptions__ is undefined. Possible bad build. HMR cannot be enabled.');
   }
 
-});
+  let currentHash;
+  let initial = true;
+  let isUnloading;
+
+  window.addEventListener('beforeunload', () => {
+    isUnloading = true;
+  });
+
+  function reload() {
+    if (isUnloading) {
+      return;
+    }
+
+    if (options.hot) {
+      log.info('App Updated, Reloading Modules');
+      update(currentHash, options);
+    } else if (options.reload) {
+      log.info('Refreshing Page');
+      window.location.reload();
+    } else {
+      log.warn('Please refresh the page manually.');
+      log.info('The `hot` and `reload` options are set to false.');
+    }
+  }
+
+  socket(options, {
+    compile({ compilerName }) {
+      log.info(`webpack: Compiling (${compilerName})`);
+    },
+
+    errors({ errors }) {
+      log.error('webpack: Encountered errors while compiling. Reload prevented.');
+
+      for (let i = 0; i < errors.length; i++) {
+        log.error(errors[i]);
+      }
+    },
+
+    hash({ hash }) {
+      currentHash = hash;
+    },
+
+    invalid({ fileName }) {
+      log.info(`App updated. Recompiling ${fileName}`);
+    },
+
+    ok() {
+      if (initial) {
+        initial = false;
+        return initial;
+      }
+
+      reload();
+    },
+
+    'window-reload': () => {
+      window.location.reload();
+    },
+
+    warnings({ warnings }) {
+      log.warn('Warnings while compiling.');
+
+      for (let i = 0; i < warnings.length; i++) {
+        log.warn(warnings[i]);
+      }
+
+      if (initial) {
+        initial = false;
+        return initial;
+      }
+
+      reload();
+    }
+
+  });
+}());

--- a/lib/util.js
+++ b/lib/util.js
@@ -122,7 +122,7 @@ module.exports = {
     if (stats.errors && stats.errors.length > 0) {
       if (options.send.errors) {
         const errors = [].concat(stats.errors).map(error => strip(error));
-        send('errors', errors);
+        send('errors', { errors });
       }
       return;
     }
@@ -133,11 +133,13 @@ module.exports = {
       return;
     }
 
-    send('hash', stats.hash);
+    const { hash, warnings } = stats;
 
-    if (stats.warnings.length > 0) {
+    send('hash', { hash });
+
+    if (warnings.length > 0) {
       if (options.send.warnings) {
-        send('warnings', stats.warnings);
+        send('warnings', { warnings });
       }
     } else {
       send('ok');

--- a/test/tests/sockets.js
+++ b/test/tests/sockets.js
@@ -129,10 +129,11 @@ describe('Sockets', () => {
       const message = parse(data);
 
       if (message.type === 'warnings') {
-        assert(message.data);
-        assert(message.data.length);
+        const { warnings } = message.data;
+        assert(warnings);
+        assert(warnings.length);
 
-        for (const warning of message.data) {
+        for (const warning of warnings) {
           assert(!ansiRegex().test(warning));
         }
 
@@ -152,10 +153,11 @@ describe('Sockets', () => {
       const message = parse(data);
 
       if (message.type === 'errors') {
-        assert(message.data);
-        assert(message.data.length);
+        const { errors } = message.data;
+        assert(errors);
+        assert(errors.length);
 
-        for (const error of message.data) {
+        for (const error of errors) {
           assert(!ansiRegex().test(error));
         }
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!
  Please note that this template is not optional.
  Please fill out _ALL_ fields, or your pull request may be rejected.
  Please do not delete this template. Please do remove this header to acknowledge this message.`

  Please place an x, no spaces, in all [ ] that apply
-->

- [x] This is a **bugfix**
- [ ] This is a new **feature**
- [ ] This is a **code refactor**
- [x] This is a **test update**
- [ ] This is a **typo fix**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

Updated current tests.

### Motivation / Use-Case

#47 raised an issue in which bundles in a `MultiCompiler` config were producing duplicate logs.

_Note: Logging may still appear duplicated in unnamed compilers in a `MultiCompiler` config. To avoid this, add the `name: (String)` property to each compiler defined in your config._

### Breaking Changes

This PR changes the way that child sockets receive data for a message. Previously, multiple named parameters could be received (even though none of the events had more than one parameter). This PR changes that to a single `Object`, with named properties. 

### Additional Info
