### PR TITLE
Added warning if HotModuleReplacementPlugin is already registered

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -63,7 +63,7 @@ function hotPlugin(compiler) {
     normalModuleFactory.hooks.parser.for('javascript/dynamic').tap('HotModuleReplacementPlugin', handler);
   });
 
-  if (compiler.options.plugins.some(plugin => plugin instanceof webpack.HotModuleReplacementPlugin)) {
+  if (compiler.options.plugins && compiler.options.plugins.some(plugin => plugin instanceof webpack.HotModuleReplacementPlugin)) {
     console.warn('HotModuleReplacementPlugin already registered, you can let autoconfigure register it for you.');
     return;
   }

--- a/lib/util.js
+++ b/lib/util.js
@@ -48,8 +48,6 @@ function hotEntry(compiler) {
 }
 
 function hotPlugin(compiler) {
-  const hmrPlugin = new webpack.HotModuleReplacementPlugin();
-
   /* istanbul ignore next */
   compiler.hooks.compilation.tap('HotModuleReplacementPlugin', (compilation, {
     normalModuleFactory
@@ -65,6 +63,12 @@ function hotPlugin(compiler) {
     normalModuleFactory.hooks.parser.for('javascript/dynamic').tap('HotModuleReplacementPlugin', handler);
   });
 
+  if (compiler.options.plugins.some(plugin => plugin instanceof webpack.HotModuleReplacementPlugin)) {
+    console.warn('HotModuleReplacementPlugin already registered, you can let autoconfigure register it for you.');
+    return;
+  }
+
+  const hmrPlugin = new webpack.HotModuleReplacementPlugin();
   hmrPlugin.apply(compiler);
 }
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!
  Please note that this template is not optional.
  Please fill out _ALL_ fields, or your pull request may be rejected.
  Please do not delete this template. Please do remove this header to acknowledge this message.`

  Please place an x, no spaces, in all [ ] that apply
-->

- [x] This is a **bugfix**
- [ ] This is a new **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **typo fix**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

Not sure how to test this change. See aditional info

### Motivation / Use-Case

Fixes a "Maximum call stack exceeded" error when HotModuleReplacementPlugin is included manually and the autoconfigure option is used.

For more context see:
https://github.com/webpack-contrib/webpack-serve/issues/149
https://www.youtube.com/watch?v=JGXAvgVHC5A

### Breaking Changes

Not a breaking change

### Additional Info

This pull request is a bit incomplete because I'm not sure how to proceed. I think it'd be great if we could log both to the terminal and to the browser but I'm not sure how logging works within the webpack ecosystem. Additionally it is unclear to me how to test this change, I'm assuming the best way to test this is to check if the warning is logged when someone registers the HotModuleReplacementPlugin manually but because of the previous point I don't really know how to log and then test whether this log happened.

Help and suggestions are very welcome :heart: 