### PR TITLE
feat: allEntries applies client entry to all entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,15 @@ Returns an `Object` containing:
 
 Type: `Object`
 
+##### allEntries
+
+Type: `Boolean`  
+Default: `false`
+
+If true and `autoConfigure` is true, will automatically configures each `entry`
+key for the webpack compiler. Typically used when working with or manipulating
+different chunks in the same compiler configuration.
+
 ##### autoConfigure
 
 Type: `Boolean`  

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const HotClientError = require('./lib/HotClientError');
 const { modifyCompiler, payload, sendData, validateCompiler } = require('./lib/util');
 
 const defaults = {
+  allEntries: false,
   autoConfigure: true,
   host: 'localhost',
   hot: true,

--- a/lib/util.js
+++ b/lib/util.js
@@ -6,13 +6,20 @@ const strip = require('strip-ansi');
 const uuid = require('uuid/v4');
 const webpack = require('webpack');
 
-function addEntry(entry, compilerName) {
+function addEntry(entry, compilerName, options) {
   const clientEntry = [`webpack-hot-client/client?${compilerName || uuid()}`];
   let newEntry = {};
 
   if (!Array.isArray(entry) && typeof entry === 'object') {
-    const [first] = Object.keys(entry);
-    newEntry[first] = clientEntry.concat(entry[first]);
+    const keys = Object.keys(entry);
+    if (options.allEntries) {
+      for (const entryName of keys) {
+        newEntry[entryName] = clientEntry.concat(entry[entryName]);
+      }
+    } else {
+      const [first] = keys;
+      newEntry[first] = clientEntry.concat(entry[first]);
+    }
   } else {
     newEntry = clientEntry.concat(entry);
   }
@@ -20,7 +27,7 @@ function addEntry(entry, compilerName) {
   return newEntry;
 }
 
-function hotEntry(compiler) {
+function hotEntry(compiler, options) {
   if (compiler.options.target !== process.env.WHC_TARGET) {
     return;
   }
@@ -36,12 +43,12 @@ function hotEntry(compiler) {
 
       validateEntry(result);
 
-      result = addEntry(result, name);
+      result = addEntry(result, name, options);
 
       return result;
     };
   } else {
-    newEntry = addEntry(entry, name);
+    newEntry = addEntry(entry, name, options);
   }
 
   compiler.hooks.entryOption.call(compiler.options.context, newEntry);
@@ -97,7 +104,7 @@ module.exports = {
     });
 
     for (const comp of [].concat(compiler.compilers || compiler)) {
-      hotEntry(comp);
+      hotEntry(comp, options);
 
       options.log.debug('Applying DefinePlugin:__hotClientOptions__');
       definePlugin.apply(comp);

--- a/package-lock.json
+++ b/package-lock.json
@@ -640,6 +640,15 @@
         "to-fast-properties": "2.0.0"
       }
     },
+    "@sinonjs/formatio": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
+      "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
+      "dev": true,
+      "requires": {
+        "samsam": "1.3.0"
+      }
+    },
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -4187,6 +4196,12 @@
         }
       }
     },
+    "just-extend": {
+      "version": "1.1.27",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
+      "integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g==",
+      "dev": true
+    },
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
@@ -4274,6 +4289,12 @@
       "integrity": "sha1-9HGh2khr5g9quVXRcRVSPdHSVdU=",
       "dev": true
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
     "log-symbols": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
@@ -4286,6 +4307,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/loglevelnext/-/loglevelnext-1.0.3.tgz",
       "integrity": "sha512-OCxd/b78TijTB4b6zVqLbMrxhebyvdZKwqpL0VHUZ0pYhavXaPD4l6Xrr4n5xqTYWiqtb0i7ikSoJY/myQ/Org=="
+    },
+    "lolex": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.0.tgz",
+      "integrity": "sha512-uJkH2e0BVfU5KOJUevbTOtpDduooSarH5PopO+LfM/vZf8Z9sJzODqKev804JYM2i++ktJfUmC1le4LwFQ1VMg==",
+      "dev": true
     },
     "loose-envify": {
       "version": "1.3.1",
@@ -4618,6 +4645,19 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.5.0.tgz",
       "integrity": "sha512-nJmSswG4As/MkRq7QZFuH/sf/yuv8ODdMZrY4Bedjp77a5MK4A6s7YbBB64c9u79EBUOfXUXBvArmvzTD0X+6g==",
       "dev": true
+    },
+    "nise": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.3.3.tgz",
+      "integrity": "sha512-v1J/FLUB9PfGqZLGDBhQqODkbLotP0WtLo9R4EJY2PPu5f5Xg4o0rA8FDlmrjFSv9vBBKcfnOSpfYYuu5RTHqg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/formatio": "2.0.0",
+        "just-extend": "1.1.27",
+        "lolex": "2.7.0",
+        "path-to-regexp": "1.7.0",
+        "text-encoding": "0.6.4"
+      }
     },
     "node-libs-browser": {
       "version": "2.1.0",
@@ -6768,6 +6808,23 @@
       "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
       "dev": true
     },
+    "path-to-regexp": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+      "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        }
+      }
+    },
     "path-type": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
@@ -7332,6 +7389,12 @@
         "ret": "0.1.15"
       }
     },
+    "samsam": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
+      "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
+      "dev": true
+    },
     "schema-utils": {
       "version": "0.4.5",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.5.tgz",
@@ -7447,6 +7510,44 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
+    },
+    "sinon": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-5.0.10.tgz",
+      "integrity": "sha512-+YT7Mjr8BpNndQqUUydO/daggF4yuOAnsVjo+5Ayx3mLLUqojfkXhDkho4HB5VgfnZYSdhxVDPbfJ2EBXFMSvA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/formatio": "2.0.0",
+        "diff": "3.5.0",
+        "lodash.get": "4.4.2",
+        "lolex": "2.7.0",
+        "nise": "1.3.3",
+        "supports-color": "5.4.0",
+        "type-detect": "4.0.8"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
     },
     "slash": {
       "version": "1.0.0",
@@ -7937,6 +8038,12 @@
       "integrity": "sha512-dQRhbNQkRnaqauC7WqSJ21EEksgT0fYZX2lqXzGkpo8JNig9zGZTYoMGvyI2nWmXlE2VSVXVDu7wLVGu/mQEsg==",
       "dev": true
     },
+    "text-encoding": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
+      "dev": true
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -8091,6 +8198,12 @@
       "requires": {
         "prelude-ls": "1.1.2"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "typedarray": {
       "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "memory-fs": "^0.4.1",
     "mocha": "^5.0.0",
     "nyc": "^11.4.1",
+    "sinon": "^5.0.10",
     "time-fix-plugin": "^2.0.0",
     "touch": "^3.1.0",
     "webpack": "^4.0.1"

--- a/test/fixtures/webpack.config-allentries.js
+++ b/test/fixtures/webpack.config-allentries.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const path = require('path');
+const TimeFixPlugin = require('time-fix-plugin');
+const webpack = require('webpack');
+
+module.exports = {
+  resolve: {
+    alias: {
+      'webpack-hot-client/client': path.resolve(__dirname, '../../client')
+    }
+  },
+  context: __dirname,
+  devtool: 'source-map',
+  entry: {
+    main: ['./app.js'],
+    server: ['./sub/client']
+  },
+  output: {
+    filename: './output.js',
+    path: path.resolve(__dirname)
+  },
+  plugins: [
+    new webpack.NamedModulesPlugin(),
+    new TimeFixPlugin()
+  ]
+};

--- a/test/tests/options.js
+++ b/test/tests/options.js
@@ -2,18 +2,37 @@
 
 /* eslint global-require: off */
 
+const sinon = require('sinon');
 const webpack = require('webpack');
 const client = require('../../index');
 
 const logLevel = 'silent';
 
 describe('Options', () => {
+  it('allEntries: true', (done) => {
+    const config = require('../fixtures/webpack.config-allentries.js');
+    const compiler = webpack(config);
+    const options = { allEntries: true, hot: true, logLevel };
+    const spy = sinon.spy(compiler.hooks.entryOption, 'call');
+
+    const { close } = client(compiler, options);
+    const { lastArg } = spy.lastCall;
+
+    expect(lastArg.main[0]).toMatch(/^webpack-hot-client\/client\?/);
+    expect(lastArg.server[0]).toMatch(/^webpack-hot-client\/client\?/);
+
+    setTimeout(() => { close(done); }, 2000);
+  }).timeout(4000);
+
   it('autoConfigure: false', (done) => {
     const config = require('../fixtures/webpack.config-invalid.js');
     const compiler = webpack(config);
     const options = { autoConfigure: false, hot: true, logLevel };
+    const spy = sinon.spy(compiler.hooks.entryOption, 'call');
 
     const { close } = client(compiler, options);
+
+    expect(spy.callCount).toBe(0);
 
     setTimeout(() => { close(done); }, 2000);
   }).timeout(4000);

--- a/test/tests/sockets.js
+++ b/test/tests/sockets.js
@@ -92,7 +92,6 @@ describe('Sockets', () => {
   it('should broadcast to child sockets', (done) => {
     const socket = new WebSocket('ws://localhost:8081');
     const socket2 = new WebSocket('ws://localhost:8081');
-    let isDone = false;
 
     expect(socket).toBeDefined();
 
@@ -101,12 +100,10 @@ describe('Sockets', () => {
         socket.on('message', (data) => {
           const message = JSON.parse(data);
 
-          if (!isDone) {
-            expect(message).toBe('test');
+          if (message === 'test') {
+            expect(true);
             socket.close();
             socket2.close();
-
-            isDone = true;
             done();
           }
         });


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!
  Please note that this template is not optional.
  Please fill out _ALL_ fields, or your pull request may be rejected.
  Please do not delete this template. Please do remove this header to acknowledge this message.`

  Please place an x, no spaces, in all [ ] that apply
-->

- [ ] This is a **bugfix**
- [x] This is a new **feature**
- [ ] This is a **code refactor**
- [x] This is a **test update**
- [ ] This is a **typo fix**
- [x] This is a **metadata update**

### For Bugs and Features; did you add new tests?

Yes

### Motivation / Use-Case

#60 Raised a good point about limiting the auto-configure to just the first entry in a key:value object entry structure. This feature provides a means to apply auto-configure to all keys in an object entry, without having the manually do so.

### Breaking Changes

None

### Additional Info

Fixes #60
