### PR TITLE
fix: __hotClientOptions__ when autoConfigure: false

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,9 +96,7 @@ module.exports = (compiler, opts) => {
     options.webSocket = { host: host.client, port };
   }
 
-  if (options.autoConfigure) {
-    modifyCompiler(compiler, options);
-  }
+  modifyCompiler(compiler, options);
 
   const compile = (comp) => {
     const compilerName = comp.name || '<unnamed compiler>';

--- a/lib/util.js
+++ b/lib/util.js
@@ -97,12 +97,13 @@ module.exports = {
     });
 
     for (const comp of [].concat(compiler.compilers || compiler)) {
-      hotEntry(comp);
+      if (options.autoConfigure) {
+        hotEntry(comp);
+        hotPlugin(comp);
+      }
 
       options.log.debug('Applying DefinePlugin:__hotClientOptions__');
       definePlugin.apply(comp);
-
-      hotPlugin(comp);
     }
   },
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -105,7 +105,7 @@ module.exports = {
 
     for (const comp of [].concat(compiler.compilers || compiler)) {
       if (options.autoConfigure) {
-        hotEntry(comp);
+        hotEntry(comp, options);
         hotPlugin(comp);
       }
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!
  Please note that this template is not optional.
  Please fill out _ALL_ fields, or your pull request may be rejected.
  Please do not delete this template. Please do remove this header to acknowledge this message.`

  Please place an x, no spaces, in all [ ] that apply
-->

- [x] This is a **bugfix**
- [ ] This is a new **feature**
- [ ] This is a **code refactor**
- [x] This is a **test update**
- [ ] This is a **typo fix**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

Rare exception, as there's no good way to determine if a plugin has been applied.

### Motivation / Use-Case

Resolves an issue that was discovered in discussion of #60 whereby `autoConfigure: false` would not apply a needed `DefinePlugin` to a compiler should a user choose to configure their client entry scripts manually.

### Breaking Changes

None, though users working around this bug by adding the plugin manually may run into unintended results.

### Additional Info
