### PR TITLE
fix: throw error when HMR plugin exists in config

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -56,12 +56,6 @@ function hotEntry(compiler, options) {
 }
 
 function hotPlugin(compiler) {
-  const pluginExists = (compiler.options.plugins || []).some(plugin => plugin instanceof HotModuleReplacementPlugin);
-
-  if (pluginExists) {
-    throw new HotClientError('HotModuleReplacementPlugin is automatically added to compilers. Please remove instances from your config before proceeding, or use the `autoConfigure: false` option.');
-  }
-
   const hmrPlugin = new HotModuleReplacementPlugin();
 
   /* istanbul ignore next */
@@ -159,8 +153,14 @@ module.exports = {
 
   validateCompiler(compiler) {
     for (const comp of [].concat(compiler.compilers || compiler)) {
-      const { entry } = comp.options;
+      const { entry, plugins } = comp.options;
       validateEntry(entry);
+
+      const pluginExists = (plugins || []).some(plugin => plugin instanceof HotModuleReplacementPlugin);
+
+      if (pluginExists) {
+        throw new HotClientError('HotModuleReplacementPlugin is automatically added to compilers. Please remove instances from your config before proceeding, or use the `autoConfigure: false` option.');
+      }
     }
   }
 };

--- a/lib/util.js
+++ b/lib/util.js
@@ -59,7 +59,7 @@ function hotPlugin(compiler) {
   const pluginExists = (compiler.options.plugins || []).some(plugin => plugin instanceof HotModuleReplacementPlugin);
 
   if (pluginExists) {
-    throw new HotClientError('HotModuleReplacementPlugin is automatically added to compilers. Please remove instances from your config before proceeding, or use the `autoConfig: false` option.');
+    throw new HotClientError('HotModuleReplacementPlugin is automatically added to compilers. Please remove instances from your config before proceeding, or use the `autoConfigure: false` option.');
   }
 
   const hmrPlugin = new HotModuleReplacementPlugin();

--- a/lib/util.js
+++ b/lib/util.js
@@ -4,7 +4,8 @@ const ParserHelpers = require('webpack/lib/ParserHelpers');
 const stringify = require('json-stringify-safe');
 const strip = require('strip-ansi');
 const uuid = require('uuid/v4');
-const webpack = require('webpack');
+const { DefinePlugin, HotModuleReplacementPlugin } = require('webpack');
+const HotClientError = require('./HotClientError');
 
 function addEntry(entry, compilerName, options) {
   const clientEntry = [`webpack-hot-client/client?${compilerName || uuid()}`];
@@ -55,7 +56,13 @@ function hotEntry(compiler, options) {
 }
 
 function hotPlugin(compiler) {
-  const hmrPlugin = new webpack.HotModuleReplacementPlugin();
+  const pluginExists = (compiler.options.plugins || []).some(plugin => plugin instanceof HotModuleReplacementPlugin);
+
+  if (pluginExists) {
+    throw new HotClientError('HotModuleReplacementPlugin is automatically added to compilers. Please remove instances from your config before proceeding, or use the `autoConfig: false` option.');
+  }
+
+  const hmrPlugin = new HotModuleReplacementPlugin();
 
   /* istanbul ignore next */
   compiler.hooks.compilation.tap('HotModuleReplacementPlugin', (compilation, {
@@ -99,7 +106,7 @@ module.exports = {
 
   modifyCompiler(compiler, options) {
     // this is how we pass the options at runtime to the client script
-    const definePlugin = new webpack.DefinePlugin({
+    const definePlugin = new DefinePlugin({
       __hotClientOptions__: stringify(options)
     });
 

--- a/test/fixtures/webpack.config-invalid-plugin.js
+++ b/test/fixtures/webpack.config-invalid-plugin.js
@@ -12,10 +12,10 @@ module.exports = {
   },
   context: __dirname,
   devtool: 'source-map',
-  entry: './app.js',
+  entry: [path.resolve(__dirname, './app.js')],
   // mode: 'development',
   output: {
-    filename: './output.js',
+    filename: 'output.js',
     path: path.resolve(__dirname)
   },
   plugins: [

--- a/test/fixtures/webpack.config-invalid-plugin.js
+++ b/test/fixtures/webpack.config-invalid-plugin.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const path = require('path');
+const TimeFixPlugin = require('time-fix-plugin');
+const webpack = require('webpack');
+
+module.exports = {
+  resolve: {
+    alias: {
+      'webpack-hot-client/client': path.resolve(__dirname, '../../client')
+    }
+  },
+  context: __dirname,
+  devtool: 'source-map',
+  entry: './app.js',
+  // mode: 'development',
+  output: {
+    filename: './output.js',
+    path: path.resolve(__dirname)
+  },
+  plugins: [
+    new webpack.NamedModulesPlugin(),
+    new webpack.HotModuleReplacementPlugin(),
+    new TimeFixPlugin()
+  ]
+};

--- a/test/tests/init.js
+++ b/test/tests/init.js
@@ -33,6 +33,13 @@ describe('Webpack Hot Client', () => {
     expect(() => { client(compiler, options); }).toThrow();
   });
 
+  it('should reject config containing HotModuleReplacementPlugin', () => {
+    const config = require('../fixtures/webpack.config-invalid-plugin.js');
+    const compiler = webpack(config);
+
+    expect(() => { client(compiler, {}); }).toThrow();
+  });
+
   it('should allow string array entry', (done) => {
     const config = require('../fixtures/webpack.config-array.js');
     const compiler = webpack(config);

--- a/test/tests/init.js
+++ b/test/tests/init.js
@@ -5,6 +5,7 @@
 
 const webpack = require('webpack');
 const client = require('../../index');
+const HotClientError = require('../../lib/HotClientError');
 
 const logLevel = 'silent';
 
@@ -37,7 +38,7 @@ describe('Webpack Hot Client', () => {
     const config = require('../fixtures/webpack.config-invalid-plugin.js');
     const compiler = webpack(config);
 
-    expect(() => { client(compiler, {}); }).toThrow();
+    expect(() => { client(compiler, {}); }).toThrow(HotClientError);
   });
 
   it('should allow string array entry', (done) => {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!
  Please note that this template is not optional.
  Please fill out _ALL_ fields, or your pull request may be rejected.
  Please do not delete this template. Please do remove this header to acknowledge this message.`

  Please place an x, no spaces, in all [ ] that apply
-->

- [x] This is a **bugfix**
- [ ] This is a new **feature**
- [ ] This is a **code refactor**
- [x] This is a **test update**
- [ ] This is a **typo fix**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

Yes

### Motivation / Use-Case

This is a pseudo-bugfix, pseudo-update. Resolves webpack-contrib/webpack-serve#149. When a `HotModuleReplacementPlugin` plugin exists in a config that is used with `webpack-hot-client` and `autoConfigure: true`, users can experience unpredictable side effects and errors. This PR throws an error to stop execution and allow users to correct their config, or use the proper hot-client option to allow for manual configuration of plugins and entries.

### Breaking Changes

None

### Additional Info
