### PR TITLE
fix: handle `all IPv4 addresses` case

### DIFF
--- a/lib/client/socket.js
+++ b/lib/client/socket.js
@@ -7,6 +7,11 @@ const maxRetries = 10;
 let retry = maxRetries;
 
 module.exports = function connect(options, handler) {
+  if (options.webSocket.host === '0.0.0.0') {
+    // eslint-disable-next-line no-param-reassign
+    options.webSocket.host = window.location.hostname;
+  }
+
   const socketUrl = url.format({
     protocol: options.https ? 'wss' : 'ws',
     hostname: options.webSocket.host,


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!
  Please note that this template is not optional.
  Please fill out _ALL_ fields, or your pull request may be rejected.
  Please do not delete this template. Please do remove this header to acknowledge this message.`

  Please place an x, no spaces, in all [ ] that apply
-->

- [x] This is a **bugfix**
- [ ] This is a new **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **typo fix**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

Can't found how do this :confused:

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for making this change.
  What existing problem does the pull request solve?
  If this Pull Request addresses an issue, please link to the issue.
-->

### Breaking Changes

no

### Additional Info

When we use `host: 0.0.0.0` web socket client should use `window.location.hostname` to connect to right host.