### PR TITLE
Update error messages from `options` to `host`

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -48,11 +48,11 @@ module.exports = (opts) => {
     };
   } else if (!options.host.server) {
     throw new HotClientError(
-      '`options.server` must be defined when setting host to an Object'
+      '`host.server` must be defined when setting host to an Object'
     );
   } else if (!options.host.client) {
     throw new HotClientError(
-      '`options.client` must be defined when setting host to an Object'
+      '`host.client` must be defined when setting host to an Object'
     );
   }
 


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [x] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Changes the error message when checking `options.host` to report `host.server` or `host.client` not being set instead of `options.server` or `options.client`

### Breaking Changes

No

### Additional Info

N/A