### PR TITLE
fix: apply DefinePlugin beforeCompile, and only once

### DIFF
--- a/lib/HotClientError.js
+++ b/lib/HotClientError.js
@@ -1,5 +1,3 @@
-'use strict';
-
 module.exports = class HotClientError extends Error {
   constructor(message) {
     super(`webpack-hot-client: ${message}`);

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -127,19 +127,33 @@ module.exports = {
   validateEntry,
 
   modifyCompiler(compiler, options) {
-    // this is how we pass the options at runtime to the client script
-    const definePlugin = new DefinePlugin({
-      __hotClientOptions__: stringify(options),
-    });
-
     for (const comp of [].concat(compiler.compilers || compiler)) {
+      // since there's a baffling lack of means to un-tap a hook, we have to
+      // keep track of a flag, per compiler indicating whether or not we should
+      // add a DefinePlugin before each compile.
+      comp.hotClient = { optionsDefined: false };
+
+      comp.hooks.beforeCompile.tap('WebpackHotClient', () => {
+        if (!comp.hotClient.optionsDefined) {
+          comp.hotClient.optionsDefined = true;
+
+          // we use the DefinePlugin to inject hot-client options into the
+          // client script. we only want this to happen once per compiler. we
+          // have to do it in a hook, since the port may not be available before
+          // the server has finished listening. compiler's shouldn't be run
+          // until setup in hot-client is complete.
+          const definePlugin = new DefinePlugin({
+            __hotClientOptions__: stringify(options),
+          });
+          options.log.info('Applying DefinePlugin:__hotClientOptions__');
+          definePlugin.apply(comp);
+        }
+      });
+
       if (options.autoConfigure) {
         hotEntry(comp, options);
         hotPlugin(comp);
       }
-
-      options.log.debug('Applying DefinePlugin:__hotClientOptions__');
-      definePlugin.apply(comp);
     }
   },
 

--- a/lib/socket-server.js
+++ b/lib/socket-server.js
@@ -97,6 +97,7 @@ function onListening(server, options) {
       const { address, port } = server._server.address();
       server.host = address;
       server.port = port;
+      options.webSocket.port = port;
 
       log.info(`WebSocket Server Listening on ${host.server}:${port}`);
     });

--- a/package.json
+++ b/package.json
@@ -34,7 +34,11 @@
   },
   "files": [
     "client/",
-    "lib/",
+    "lib/compiler.js",
+    "lib/HotClientError.js",
+    "lib/index.js",
+    "lib/options.js",
+    "lib/socket-server.js",
     "LICENSE",
     "README.md"
   ],


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

The `DefinePlugin`, used to inject hot-client options into the client script, was being instantiated too early, before the socket server had finished listening and allocating a port. This PR moves the application of the plugin to the `beforeCompile` hook for compiler(s), which should ensure that the plugin has the most up-to-date options before being applied. This is only an issue when a `port` option with a value of `0` is used (which is the default).

### Breaking Changes

None, but as a best practice a compiler should not be started/run/watched until hot-client's server has finished listening.

### Additional Info