### PR TITLE
chore: move webpack-defaults to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "merge-options": "^1.0.1",
     "strip-ansi": "^4.0.0",
     "uuid": "^3.1.0",
-    "webpack-defaults": "github:webpack-contrib/webpack-defaults",
     "webpack-log": "^1.1.1",
     "ws": "^4.0.0"
   },
@@ -91,6 +90,7 @@
     "standard-version": "^4.4.0",
     "time-fix-plugin": "^2.0.0",
     "touch": "^3.1.0",
+    "webpack-defaults": "github:webpack-contrib/webpack-defaults",
     "webpack": "^4.0.1"
   },
   "keywords": [


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [x] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->
webpack-defaults is a devDependency, that for some reason changes the `package.json` of a downstream project. That should not happen.

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info