### PR TITLE
fix: don't break if no options passed

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -28,7 +28,7 @@ const defaults = {
   test: false,
 };
 
-module.exports = (opts) => {
+module.exports = (opts = {}) => {
   validate({ name: 'webpack-hot-client', schema, target: opts });
 
   const options = merge({}, defaults, opts);

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -4,7 +4,7 @@ const getOptions = require('../lib/options');
 
 describe('options', () => {
   test('defaults', () => {
-    const options = getOptions({});
+    const options = getOptions();
     expect(options).toMatchSnapshot({
       stats: {
         context: expect.stringMatching(/(webpack-hot-client|project)$/),


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

If no options were passed
```js
webpackHotClient(compiler)
```
client throws validation error 
```js
...\node_modules\@webpack-contrib\schema-utils\dist\validate-options.js:90
      throw err;
      ^

ValidationError: undefined

  Options Validation Error

  options.target  is a required property
```

Since there is no required options, it should be allowed to run webpackHotClient without passing options as second argument.

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info