### PR TITLE
fix: incorrect check for existing socket clients

### DIFF
--- a/lib/socket-server.js
+++ b/lib/socket-server.js
@@ -61,7 +61,7 @@ function onConnection(server, options) {
 
     // only send stats to newly connected clients, if no previous clients have
     // connected and stats has been modified by webpack
-    if (options.stats && options.stats.toJson && !server.clients.length) {
+    if (options.stats && options.stats.toJson && server.clients.size === 1) {
       const jsonStats = options.stats.toJson(options.stats);
 
       /* istanbul ignore if */


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->
Fixes #61. 

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->
Shouldn't break anything, all tests still pass.

### Additional Info
Here's a repo where the issue & the fix can be tested easily: [noppa/webpack-hot-client-refresh-issue-sscce](https://github.com/noppa/webpack-hot-client-refresh-issue-sscce).

I also have the same fix for version 3, here: 91cac08bc.
Not sure how or if that should be merged, but it's there if you want to patch v3.