### PR TITLE
[WIP] feat: add support for a split `server` / `client` configuration

### DIFF
--- a/lib/client/socket.js
+++ b/lib/client/socket.js
@@ -6,11 +6,11 @@ const maxRetries = 10;
 let retry = maxRetries;
 
 module.exports = function connect(options, handler) {
-  const { host } = options.webSocket;
+  const { host, port, secure } = options.webSocketClient;
   const socketUrl = url.format({
-    protocol: options.https ? 'wss' : 'ws',
+    protocol: secure ? 'wss' : 'ws',
     hostname: host === '*' ? window.location.hostname : host,
-    port: options.webSocket.port,
+    port: port,
     slashes: true,
   });
 

--- a/lib/options.js
+++ b/lib/options.js
@@ -24,6 +24,7 @@ const defaults = {
     warnings: true,
   },
   server: null,
+  client: {},
   stats: {
     context: process.cwd(),
   },
@@ -59,24 +60,28 @@ module.exports = (opts = {}) => {
     );
   }
 
-  const { server } = options;
+  const { server, client } = options;
+  const hasServer = server && server.listening;
+  options.webSocketServer = {};
 
-  if (server && !server.listening) {
-    throw new HotClientError(
-      '`options.server` must be a running/listening net.Server instance'
-    );
-  } else if (server) {
-    options.webSocket = {
-      host: server.address().address,
-      port: server.address().port,
-    };
-
-    if (server instanceof HttpsServer && typeof options.https === 'undefined') {
-      options.https = true;
-    }
-  } else {
-    options.webSocket = { host: options.host.client, port: options.port };
+  if (hasServer && server instanceof HttpsServer && typeof options.https === 'undefined') {
+    options.https = true;
   }
+
+  if (hasServer) {
+    options.webSocketServer = { server };
+  } else {
+    options.webSocketServer = {
+        host: server && server.host || options.host.server,
+        port: server && server.port || options.port,
+    }
+  }
+
+  options.webSocketClient = {
+    host: client.host || options.host.client || (hasServer && server.address().address) || '*',
+    port: client.port || (hasServer && server.address().port) || options.port,
+    secure: typeof client.secure !== 'undefined' ? client.secure : options.https,
+  };
 
   return options;
 };

--- a/lib/socket-server.js
+++ b/lib/socket-server.js
@@ -3,9 +3,8 @@ const strip = require('strip-ansi');
 const WebSocket = require('ws');
 
 function getServer(options) {
-  const { host, log, port, server } = options;
-  const wssOptions = server ? { server } : { host: host.server, port };
-  const wss = new WebSocket.Server(wssOptions);
+  const { log, webSocketServer } = options;
+  const wss = new WebSocket.Server(webSocketServer);
 
   onConnection(wss, options);
   onError(wss, options);


### PR DESCRIPTION
* add options `{server: {host, port}, client: {host, port, secure}}`
* secondary effect options.server can be a server instance or a definition object
* all options are set in importance order, compatiblity is preserved (at least it should be)
* for clarity introduce websocketServer & websocketClient computed options

<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [X] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

see #79 

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

### Breaking Changes

Trying my best not to.
<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info