### PR TITLE
Add link to Websocket compatibility table.

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,9 @@ Because this module leverages _native_ `WebSockets`, the browser support for thi
 module is limited to only those browsers which support native `WebSocket`. That
 typically means the last two major versions of a particular browser.
 
+Please visit [caniuse.com](https://caniuse.com/#feat=websockets) for a full
+compatibility table.
+
 _Note: We won't be accepting requests for changes to this facet of the module._
 
 ## API


### PR DESCRIPTION
This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [x] **metadata update**

### Motivation / Use-Case

The README implies that native Websocket support is fairly new (last two browser versions), which may scare people away from this library. They've really been supported by every browser since 2013. The only reason to avoid using this library is to support IE9 or ancient Android Browser versions in development mode.

This clarifies that, and adds a link to caniuse for a full compatibility table.