### PR TITLE
fix(schemas/options): add support custom targets

### DIFF
--- a/schemas/options.json
+++ b/schemas/options.json
@@ -85,7 +85,10 @@
     "validTargets": {
       "type": "array",
       "items": {
-        "type": "string"
+        "anyOf": [
+          { "type": "string" },
+          { "instanceof": "Function" }
+        ]
       }
     }
   },

--- a/test/__snapshots__/options.test.js.snap
+++ b/test/__snapshots__/options.test.js.snap
@@ -68,6 +68,7 @@ Object {
   "validTargets": Array [
     "web",
     "batman",
+    [Function],
   ],
   "webSocket": Object {
     "host": "localhost",

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -39,7 +39,7 @@ describe('options', () => {
       stats: {
         context: '/',
       },
-      validTargets: ['batman'],
+      validTargets: ['batman', function dummyTarget() {}],
       // we pass this to force the log instance to be unique, to assert log
       // option differences
       test: true,


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case
We use a custom Webpack target function and therefore need to add a function to the `validTargets` option.
<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

### Breaking Changes
None
<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info