### PR TITLE
Fix bugs when using the server option together with different client/server URLs

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -49,7 +49,7 @@ module.exports = (opts = {}) => {
       client: options.host,
       server: options.host,
     };
-  } else if (!options.host.server) {
+  } else if (!options.host.server && !options.server) {
     throw new HotClientError(
       '`host.server` must be defined when setting host to an Object'
     );
@@ -64,7 +64,7 @@ module.exports = (opts = {}) => {
       client: options.port,
       server: options.port,
     };
-  } else if (isNaN(parseInt(options.port.server, 10))) {
+  } else if (isNaN(parseInt(options.port.server, 10)) && !options.server) {
     throw new HotClientError(
       '`port.server` must be defined when setting host to an Object'
     );

--- a/lib/options.js
+++ b/lib/options.js
@@ -86,7 +86,7 @@ module.exports = (opts = {}) => {
 
   if (server && server.listening) {
     options.webSocket = {
-      host: server.address().address,
+      host: options.host.client || server.address().address,
       // a port.client value of 0 will be falsy, so it should pull the server port
       port: options.port.client || server.address().port,
     };


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

Having a different browser address and server address is useful if there is a proxy in between. The server option is useful because it removes the need to have two servers and two ports.

There are two bugs fixed:
- The validation code previously rejected a configuration such as this:
```javascript
{
  host: {
    client: 'someurl',
  },
  port: {
    client: 80
  },
  server,
}
```
even though the provided server is already listening on a host/port

- When the server option was used, the client ignored the `host.client` setting

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

None

### Additional Info