### PR TITLE
Remove invalid bin entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   "author": "Andrew Powell <andrew@shellscape.org>",
   "homepage": "https://github.com/webpack-contrib/webpack-hot-client",
   "bugs": "https://github.com/webpack-contrib/webpack-hot-client/issues",
-  "bin": "",
   "main": "lib/index.js",
   "engines": {
     "node": ">= 6.9.0 < 7.0.0 || >= 8.9.0"


### PR DESCRIPTION
This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [x] **metadata update**

### Motivation / Use-Case

the latest version of yarn warns on invalid bin fields:
```
warning webpack-hot-client@4.1.2: Invalid bin field for "webpack-hot-client".
```

I don't think that the empty bin field has any meaning, so I think removing it should be fine.

### Breaking Changes

no

### Additional Info