### PR TITLE
fix for newer node versions

### DIFF
--- a/lib/socket-server.js
+++ b/lib/socket-server.js
@@ -49,7 +49,7 @@ function onConnection(server, options) {
 
     socket.on('error', (err) => {
       /* istanbul ignore next */
-      if (err.errno !== 'ECONNRESET') {
+      if (err.errno !== 'ECONNRESET' && err.code !== 'ECONNRESET') {
         log.warn('client socket error', JSON.stringify(err));
       }
     });


### PR DESCRIPTION
node now guarantees that the errorno is numeric: https://github.com/nodejs/node/commit/1432065e9dc77218507f328b63cb7f5d279dd6e9

since that enum could change, let's just check the code.
keep the old errono for backwards compat

<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->
too much junk in stdout

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->
none

### Additional Info