### PR TITLE
Update ParserHelpers to JavascriptParserHelpers for Webpack 5 compatibility

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -1,4 +1,4 @@
-const ParserHelpers = require('webpack/lib/ParserHelpers');
+const ParserHelpers = require('webpack/lib/javascript/JavascriptParserHelpers');
 const stringify = require('json-stringify-safe');
 const uuid = require('uuid/v4');
 const { DefinePlugin, HotModuleReplacementPlugin } = require('webpack');


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

See #111 

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

### Breaking Changes

I'm not sure if this would work with prior version of `webpack` so perhaps a major release would be required.

### Additional Info

I'm not actually using this library anymore so I'd rather not work on this further, but wanted to get the ball rolling for others.